### PR TITLE
fix: Accept undefined pluginConfig

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,7 @@ const loadChangelogConfig = require('./load/changelog-config');
 /**
  * Generate the changelog for all the commits since the last release.
  *
- * @param {Object} pluginConfig semantic-release configuration
+ * @param {Object} [pluginConfig={}] semantic-release configuration
  * @param {string} pluginConfig.preset conventional-changelog preset ('angular', 'atom', 'codemirror', 'ember', 'eslint', 'express', 'jquery', 'jscs', 'jshint')
  * @param {string} pluginConfig.config requierable npm package with a custom conventional-changelog preset
  * @param {Object} pluginConfig.parserOpts additional `conventional-changelog-parser` options that will overwrite ones loaded by `preset` or `config`.
@@ -19,7 +19,7 @@ const loadChangelogConfig = require('./load/changelog-config');
  * @param {Object} options semantic-release options
  * @param {releaseNotesGeneratorCallback} callback The callback called with the release note.
  */
-module.exports = async (pluginConfig, options, callback) => {
+module.exports = async (pluginConfig = {}, options, callback) => {
   const cb = typeof options === 'function' ? options : callback;
 
   try {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -120,3 +120,13 @@ test.serial('Handle error in "conventional-changelog" and wrap in "SemanticRelea
 
   t.true(error instanceof SemanticReleaseError);
 });
+
+test.serial('Accept an undefined "pluginConfig"', async t => {
+  await commits(['fix(scope1): First fix', 'feat(scope2): Second feature']);
+  const changelog = await pify(releaseNotesGenerator)(undefined);
+
+  t.regex(changelog, /### Bug Fixes/);
+  t.regex(changelog, /\* \*\*scope1:\*\* First fix/);
+  t.regex(changelog, /### Features/);
+  t.regex(changelog, /\* \*\*scope2:\*\* Second feature/);
+});


### PR DESCRIPTION
Similar to semantic-release/commit-analyzer#12

Now that the plugin is the default one, a configuration in the `release.generateNotes` is not mandatory, therefore the plugin has to handle the case where `pluginConfig` is `undefined`.