### PR TITLE
Remove semantic-release from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,9 +99,6 @@
     ],
     "all": true
   },
-  "peerDependencies": {
-    "semantic-release": ">= 4"
-  },
   "prettier": {
     "printWidth": 120,
     "singleQuote": true,


### PR DESCRIPTION
Unnecessary for default plugins.
Avoid the following warning when installing `semantic-release`: `npm WARN @semantic-release/release-notes-generator@4.0.1 requires a peer of semantic-release@>= 4 but none was installed.`