### PR TITLE
Generate compare URL with git tag if available

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,20 +19,19 @@ const debug = require('debug')('semantic-release:release-notes-generator');
  * @param {Object} options semantic-release options
  * @param {Object} options.pkg normalized `package.json`
  * @param {Array<Object>} options.commits array of commits, each containing `hash` and `message`
- * @param {Object>} options.lastRelease last release with `gitHead` corresponding to the commit hash used to make the last release
- * @param {Object>} options.nextRelease next release with `gitHead` corresponding to the commit hash used to make the  release and the release `version`
+ * @param {Object>} options.lastRelease last release with `gitHead` corresponding to the commit hash used to make the last release and `gitTag` corresponding to the git tag associated with `gitHead`
+ * @param {Object>} options.nextRelease next release with `gitHead` corresponding to the commit hash used to make the  release, the release `version` and `gitTag` corresponding to the git tag associated with `gitHead`
  */
-async function releaseNotesGenerator(
-  pluginConfig,
-  {pkg, commits, lastRelease: {gitHead: previousTag}, nextRelease: {gitHead: currentTag, version}}
-) {
+async function releaseNotesGenerator(pluginConfig, {pkg, commits, lastRelease, nextRelease}) {
   const {parserOpts, writerOpts} = await loadChangelogConfig(pluginConfig);
   commits = commits.map(rawCommit =>
     Object.assign(rawCommit, conventionalCommitsParser(rawCommit.message, parserOpts))
   );
   const {default: protocol, domain: host, project: repository, user: owner} = hostedGitInfo.fromUrl(pkg.repository.url);
+  const previousTag = lastRelease.gitTag || lastRelease.gitHead;
+  const currentTag = nextRelease.gitTag || nextRelease.gitHead;
   const context = {
-    version,
+    version: nextRelease.version,
     host: url.format({protocol, host}),
     owner,
     repository,
@@ -42,7 +41,7 @@ async function releaseNotesGenerator(
     packageData: pkg,
   };
 
-  debug('version: %o', version);
+  debug('version: %o', nextRelease.version);
   debug('host: %o', host);
   debug('owner: %o', owner);
   debug('repository: %o', repository);


### PR DESCRIPTION
With semantic-release/semantic-release#515 `semantic-release` will pass the git tag in `lastRelease` and `nextRelease` if they are available.

This PR allow to generate the compare URL in the release note with the git tag rather than the git head if the git tag are available. That allow to make more compact and readable compare URLs.