### PR TITLE
Support custom repository URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "conventional-commits-parser": "^2.0.0",
     "debug": "^3.1.0",
     "get-stream": "^3.0.0",
-    "hosted-git-info": "^2.5.0",
+    "git-url-parse": "^7.0.1",
     "import-from": "^2.1.0",
     "into-stream": "^3.1.0",
     "lodash": "^4.17.4"

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -2,7 +2,7 @@ import {promisify} from 'util';
 import test from 'ava';
 import releaseNotesGenerator from '..';
 
-const url = 'https://github.com/owner/repo';
+const url = 'https://github.com/owner/repo.git';
 const lastRelease = {gitTag: 'v1.0.0'};
 const nextRelease = {gitTag: 'v2.0.0', version: '2.0.0'};
 
@@ -163,6 +163,54 @@ test('Use "gitHead" from "lastRelease" and "nextRelease" if "gitTag" is not defi
   t.regex(
     changelog,
     new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://github.com/owner/repo\\/commits\\/222\\)\\)`)
+  );
+});
+
+test('Accept a custom repository URL', async t => {
+  const commits = [
+    {hash: '111', message: 'fix(scope1): First fix'},
+    {hash: '222', message: 'feat(scope2): Second feature'},
+  ];
+  const changelog = await promisify(releaseNotesGenerator)(
+    {},
+    {pkg: {repository: {url: 'http://domain.com:90/owner/repo'}}, lastRelease, nextRelease, commits}
+  );
+
+  t.regex(changelog, new RegExp(`<a name="2.0.0"></a>`));
+  t.regex(changelog, new RegExp(`\\(http://domain.com:90/owner/repo/compare/v1\\.0\\.0\\.\\.\\.v2\\.0\\.0\\)`));
+  t.regex(changelog, /### Bug Fixes/);
+  t.regex(
+    changelog,
+    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(http://domain.com:90/owner/repo\\/commits\\/111\\)\\)`)
+  );
+  t.regex(changelog, /### Features/);
+  t.regex(
+    changelog,
+    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(http://domain.com:90/owner/repo\\/commits\\/222\\)\\)`)
+  );
+});
+
+test('Accept a custom repository URL with git format', async t => {
+  const commits = [
+    {hash: '111', message: 'fix(scope1): First fix'},
+    {hash: '222', message: 'feat(scope2): Second feature'},
+  ];
+  const changelog = await promisify(releaseNotesGenerator)(
+    {},
+    {pkg: {repository: {url: 'git@domain.com:owner/repo.git'}}, lastRelease, nextRelease, commits}
+  );
+
+  t.regex(changelog, new RegExp(`<a name="2.0.0"></a>`));
+  t.regex(changelog, new RegExp(`\\(https://domain.com/owner/repo/compare/v1\\.0\\.0\\.\\.\\.v2\\.0\\.0\\)`));
+  t.regex(changelog, /### Bug Fixes/);
+  t.regex(
+    changelog,
+    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://domain.com/owner/repo\\/commits\\/111\\)\\)`)
+  );
+  t.regex(changelog, /### Features/);
+  t.regex(
+    changelog,
+    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://domain.com/owner/repo\\/commits\\/222\\)\\)`)
   );
 });
 


### PR DESCRIPTION
[hosted-git-info](https://github.com/npm/hosted-git-info) supports only `github`, `bitbucket` and `gitlab` URLs. So custom GHE or standalone Git repository were not supported (i.e. `http://domain.com:90/owner/repo` would fail and throw an error).

The plugin now supports any type of git URLs:
- `https://github.com/owner/repo`
- `https://github.com/owner/repo.git`
- `https://gitlab.com/owner/repo`
- `http://domain.com:90/owner/repo`
- `git@domain.com:owner/repo.git` => in that case it will be converted to `https://domain.com/owner/repo`
