### PR TITLE
Generate commits and issues URL based on git host

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const url = require('url');
+const {find} = require('lodash');
 const getStream = require('get-stream');
 const intoStream = require('into-stream');
 const gitUrlParse = require('git-url-parse');
@@ -6,6 +7,7 @@ const conventionalCommitsParser = require('conventional-commits-parser').sync;
 const conventionalChangelogWriter = require('conventional-changelog-writer');
 const debug = require('debug')('semantic-release:release-notes-generator');
 const loadChangelogConfig = require('./lib/load-changelog-config');
+const HOSTS_CONFIG = require('./lib/hosts-config');
 
 /**
  * Generate the changelog for all the commits since the last release.
@@ -39,6 +41,7 @@ async function releaseNotesGenerator(pluginConfig, {commits, lastRelease, nextRe
     previousTag,
     currentTag,
     linkCompare: currentTag && previousTag,
+    ...(find(HOSTS_CONFIG, conf => conf.hostname === hostname) || HOSTS_CONFIG.default),
   };
 
   debug('version: %o', nextRelease.version);

--- a/lib/hosts-config.js
+++ b/lib/hosts-config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  github: {
+    hostname: 'github.com',
+    issue: 'issues',
+    commit: 'commit',
+  },
+  bitbucket: {
+    hostname: 'bitbucket.org',
+    issue: 'issue',
+    commit: 'commits',
+  },
+  gitlab: {
+    hostname: 'gitlab.com',
+    issue: 'issues',
+    commit: 'commit',
+  },
+  default: {
+    issue: 'issues',
+    commit: 'commit',
+  },
+};

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -18,12 +18,12 @@ test('Use "conventional-changelog-angular" by default', async t => {
   t.regex(changelog, /### Bug Fixes/);
   t.regex(
     changelog,
-    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://github.com/owner/repo\\/commits\\/111\\)\\)`)
+    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://github.com/owner/repo\\/commit\\/111\\)\\)`)
   );
   t.regex(changelog, /### Features/);
   t.regex(
     changelog,
-    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://github.com/owner/repo\\/commits\\/222\\)\\)`)
+    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://github.com/owner/repo\\/commit\\/222\\)\\)`)
   );
 });
 
@@ -43,14 +43,14 @@ test('Accept a "preset" option', async t => {
   t.regex(
     changelog,
     new RegExp(
-      `First fix .* \\(\\[111\\]\\(https://github.com/owner/repo\\/commits\\/111\\)\\), closes \\[#123\\]\\(https://github.com/owner/repo\\/issues\\/123\\)`
+      `First fix .* \\(\\[111\\]\\(https://github.com/owner/repo\\/commit\\/111\\)\\), closes \\[#123\\]\\(https://github.com/owner/repo\\/issues\\/123\\)`
     )
   );
   t.regex(changelog, /### Update/);
   t.regex(
     changelog,
     new RegExp(
-      `Second feature .* \\(\\[222\\]\\(https://github.com/owner/repo\\/commits\\/222\\)\\), closes \\[#456\\]\\(https://github.com/owner/repo\\/issues\\/456\\)`
+      `Second feature .* \\(\\[222\\]\\(https://github.com/owner/repo\\/commit\\/222\\)\\), closes \\[#456\\]\\(https://github.com/owner/repo\\/issues\\/456\\)`
     )
   );
 });
@@ -71,14 +71,14 @@ test('Accept a "config" option', async t => {
   t.regex(
     changelog,
     new RegExp(
-      `First fix .* \\(\\[111\\]\\(https://github.com/owner/repo\\/commits\\/111\\)\\), closes \\[#123\\]\\(https://github.com/owner/repo\\/issues\\/123\\)`
+      `First fix .* \\(\\[111\\]\\(https://github.com/owner/repo\\/commit\\/111\\)\\), closes \\[#123\\]\\(https://github.com/owner/repo\\/issues\\/123\\)`
     )
   );
   t.regex(changelog, /### Update/);
   t.regex(
     changelog,
     new RegExp(
-      `Second feature .* \\(\\[222\\]\\(https://github.com/owner/repo\\/commits\\/222\\)\\), closes \\[#456\\]\\(https://github.com/owner/repo\\/issues\\/456\\)`
+      `Second feature .* \\(\\[222\\]\\(https://github.com/owner/repo\\/commit\\/222\\)\\), closes \\[#456\\]\\(https://github.com/owner/repo\\/issues\\/456\\)`
     )
   );
 });
@@ -102,14 +102,14 @@ test('Accept a "parseOpts" and "writerOpts" objects as option', async t => {
   t.regex(
     changelog,
     new RegExp(
-      `First fix .* \\(\\[111\\]\\(https://github.com/owner/repo\\/commits\\/111\\)\\), closes \\[#123\\]\\(https://github.com/owner/repo\\/issues\\/123\\)`
+      `First fix .* \\(\\[111\\]\\(https://github.com/owner/repo\\/commit\\/111\\)\\), closes \\[#123\\]\\(https://github.com/owner/repo\\/issues\\/123\\)`
     )
   );
   t.regex(changelog, /### Update/);
   t.regex(
     changelog,
     new RegExp(
-      `Second feature .* \\(\\[222\\]\\(https://github.com/owner/repo\\/commits\\/222\\)\\), closes \\[#456\\]\\(https://github.com/owner/repo\\/issues\\/456\\)`
+      `Second feature .* \\(\\[222\\]\\(https://github.com/owner/repo\\/commit\\/222\\)\\), closes \\[#456\\]\\(https://github.com/owner/repo\\/issues\\/456\\)`
     )
   );
 });
@@ -149,12 +149,12 @@ test('Use "gitHead" from "lastRelease" and "nextRelease" if "gitTag" is not defi
   t.regex(changelog, /### Bug Fixes/);
   t.regex(
     changelog,
-    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://github.com/owner/repo\\/commits\\/111\\)\\)`)
+    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://github.com/owner/repo\\/commit\\/111\\)\\)`)
   );
   t.regex(changelog, /### Features/);
   t.regex(
     changelog,
-    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://github.com/owner/repo\\/commits\\/222\\)\\)`)
+    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://github.com/owner/repo\\/commit\\/222\\)\\)`)
   );
 });
 
@@ -173,12 +173,12 @@ test('Accept a custom repository URL', async t => {
   t.regex(changelog, /### Bug Fixes/);
   t.regex(
     changelog,
-    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(http://domain.com:90/owner/repo\\/commits\\/111\\)\\)`)
+    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(http://domain.com:90/owner/repo\\/commit\\/111\\)\\)`)
   );
   t.regex(changelog, /### Features/);
   t.regex(
     changelog,
-    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(http://domain.com:90/owner/repo\\/commits\\/222\\)\\)`)
+    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(http://domain.com:90/owner/repo\\/commit\\/222\\)\\)`)
   );
 });
 
@@ -197,12 +197,12 @@ test('Accept a custom repository URL with git format', async t => {
   t.regex(changelog, /### Bug Fixes/);
   t.regex(
     changelog,
-    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://domain.com/owner/repo\\/commits\\/111\\)\\)`)
+    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://domain.com/owner/repo\\/commit\\/111\\)\\)`)
   );
   t.regex(changelog, /### Features/);
   t.regex(
     changelog,
-    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://domain.com/owner/repo\\/commits\\/222\\)\\)`)
+    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://domain.com/owner/repo\\/commit\\/222\\)\\)`)
   );
 });
 
@@ -221,12 +221,12 @@ test('Accept a custom repository URL with git+http format', async t => {
   t.regex(changelog, /### Bug Fixes/);
   t.regex(
     changelog,
-    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(http://domain.com:90/owner/repo\\/commits\\/111\\)\\)`)
+    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(http://domain.com:90/owner/repo\\/commit\\/111\\)\\)`)
   );
   t.regex(changelog, /### Features/);
   t.regex(
     changelog,
-    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(http://domain.com:90/owner/repo\\/commits\\/222\\)\\)`)
+    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(http://domain.com:90/owner/repo\\/commit\\/222\\)\\)`)
   );
 });
 
@@ -245,12 +245,60 @@ test('Accept a custom repository URL with git+https format', async t => {
   t.regex(changelog, /### Bug Fixes/);
   t.regex(
     changelog,
-    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://domain.com:90/owner/repo\\/commits\\/111\\)\\)`)
+    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://domain.com:90/owner/repo\\/commit\\/111\\)\\)`)
   );
   t.regex(changelog, /### Features/);
   t.regex(
     changelog,
-    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://domain.com:90/owner/repo\\/commits\\/222\\)\\)`)
+    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://domain.com:90/owner/repo\\/commit\\/222\\)\\)`)
+  );
+});
+
+test('Accept a Bitbucket repository URL', async t => {
+  const commits = [
+    {hash: '111', message: 'fix(scope1): First fix'},
+    {hash: '222', message: 'feat(scope2): Second feature'},
+  ];
+  const changelog = await releaseNotesGenerator(
+    {},
+    {options: {repositoryUrl: 'git+https://bitbucket.org/owner/repo'}, lastRelease, nextRelease, commits}
+  );
+
+  t.regex(changelog, new RegExp(`<a name="2.0.0"></a>`));
+  t.regex(changelog, new RegExp(`\\(https://bitbucket.org/owner/repo/compare/v1\\.0\\.0\\.\\.\\.v2\\.0\\.0\\)`));
+  t.regex(changelog, /### Bug Fixes/);
+  t.regex(
+    changelog,
+    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://bitbucket.org/owner/repo\\/commits\\/111\\)\\)`)
+  );
+  t.regex(changelog, /### Features/);
+  t.regex(
+    changelog,
+    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://bitbucket.org/owner/repo\\/commits\\/222\\)\\)`)
+  );
+});
+
+test('Accept a Gitlab repository URL', async t => {
+  const commits = [
+    {hash: '111', message: 'fix(scope1): First fix'},
+    {hash: '222', message: 'feat(scope2): Second feature'},
+  ];
+  const changelog = await releaseNotesGenerator(
+    {},
+    {options: {repositoryUrl: 'git+https://gitlab.com/owner/repo'}, lastRelease, nextRelease, commits}
+  );
+
+  t.regex(changelog, new RegExp(`<a name="2.0.0"></a>`));
+  t.regex(changelog, new RegExp(`\\(https://gitlab.com/owner/repo/compare/v1\\.0\\.0\\.\\.\\.v2\\.0\\.0\\)`));
+  t.regex(changelog, /### Bug Fixes/);
+  t.regex(
+    changelog,
+    new RegExp(`scope1:.*First fix \\(\\[111\\]\\(https://gitlab.com/owner/repo\\/commit\\/111\\)\\)`)
+  );
+  t.regex(changelog, /### Features/);
+  t.regex(
+    changelog,
+    new RegExp(`scope2:.*Second feature \\(\\[222\\]\\(https://gitlab.com/owner/repo\\/commit\\/222\\)\\)`)
   );
 });
 


### PR DESCRIPTION
Pass the `commit` and `issue` parameters to `conventional-changelog-writer` in order to generate commits and issues URL based on the git host

Fix semantic-release/semantic-release#543