### PR TITLE
feat: use `cwd` and `env` options passed by core

### DIFF
--- a/lib/load-changelog-config.js
+++ b/lib/load-changelog-config.js
@@ -5,20 +5,25 @@ const conventionalChangelogAngular = require('conventional-changelog-angular');
 /**
  * Load `conventional-changelog-parser` options. Handle presets that return either a `Promise<Array>` or a `Promise<Function>`.
  *
- * @param {Object} preset conventional-changelog preset ('angular', 'atom', 'codemirror', 'ember', 'eslint', 'express', 'jquery', 'jscs', 'jshint')
- * @param {string} config requierable npm package with a custom conventional-changelog preset
- * @param {Object} parserOpts additionnal `conventional-changelog-parser` options that will overwrite ones loaded by `preset` or `config`.
- * @param {Object} writerOpts additionnal `conventional-changelog-writer` options that will overwrite ones loaded by `preset` or `config`.
+ * @param {Object} pluginConfig The plugin configuration.
+ * @param {Object} pluginConfig.preset conventional-changelog preset ('angular', 'atom', 'codemirror', 'ember', 'eslint', 'express', 'jquery', 'jscs', 'jshint')
+ * @param {string} pluginConfig.config Requierable npm package with a custom conventional-changelog preset
+ * @param {Object} pluginConfig.parserOpts Additionnal `conventional-changelog-parser` options that will overwrite ones loaded by `preset` or `config`.
+ * @param {Object} pluginConfig.writerOpts Additionnal `conventional-changelog-writer` options that will overwrite ones loaded by `preset` or `config`.
+ * @param {Object} context The semantic-release context.
+ * @param {Array<Object>} context.commits The commits to analyze.
+ * @param {String} context.cwd The current working directory.
+ *
  * @return {Promise<Object>} a `Promise` that resolve to the `conventional-changelog-core` config.
  */
-module.exports = async ({preset, config, parserOpts, writerOpts}) => {
+module.exports = async ({preset, config, parserOpts, writerOpts}, {cwd}) => {
   let loadedConfig;
 
   if (preset) {
     const presetPackage = `conventional-changelog-${preset.toLowerCase()}`;
-    loadedConfig = importFrom.silent(__dirname, presetPackage) || importFrom(process.cwd(), presetPackage);
+    loadedConfig = importFrom.silent(__dirname, presetPackage) || importFrom(cwd, presetPackage);
   } else if (config) {
-    loadedConfig = importFrom.silent(__dirname, config) || importFrom(process.cwd(), config);
+    loadedConfig = importFrom.silent(__dirname, config) || importFrom(cwd, config);
   } else {
     loadedConfig = conventionalChangelogAngular;
   }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,9 @@
     ],
     "all": true
   },
+  "peerDependencies": {
+    "semantic-release": ">=15.8.0 <16.0.0"
+  },
   "prettier": {
     "printWidth": 120,
     "trailingComma": "es5"

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -3,6 +3,7 @@ import test from 'ava';
 import escape from 'escape-string-regexp';
 import releaseNotesGenerator from '..';
 
+const cwd = process.cwd();
 const repositoryUrl = 'https://github.com/owner/repo';
 const lastRelease = {gitTag: 'v1.0.0'};
 const nextRelease = {gitTag: 'v2.0.0', version: '2.0.0'};
@@ -12,7 +13,7 @@ test('Use "conventional-changelog-angular" by default', async t => {
     {hash: '111', message: 'fix(scope1): First fix'},
     {hash: '222', message: 'feat(scope2): Second feature'},
   ];
-  const changelog = await releaseNotesGenerator({}, {options: {repositoryUrl}, lastRelease, nextRelease, commits});
+  const changelog = await releaseNotesGenerator({}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
 
   t.regex(changelog, new RegExp(escape('(https://github.com/owner/repo/compare/v1.0.0...v2.0.0)')));
   t.regex(changelog, /### Bug Fixes/);
@@ -31,7 +32,7 @@ test('Accept a "preset" option', async t => {
   ];
   const changelog = await releaseNotesGenerator(
     {preset: 'eslint'},
-    {options: {repositoryUrl}, lastRelease, nextRelease, commits}
+    {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
   );
 
   t.regex(changelog, new RegExp(escape('(https://github.com/owner/repo/compare/v1.0.0...v2.0.0)')));
@@ -62,7 +63,7 @@ test('Accept a "config" option', async t => {
   ];
   const changelog = await releaseNotesGenerator(
     {config: 'conventional-changelog-eslint'},
-    {options: {repositoryUrl}, lastRelease, nextRelease, commits}
+    {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
   );
 
   t.regex(changelog, new RegExp(escape('(https://github.com/owner/repo/compare/v1.0.0...v2.0.0)')));
@@ -101,7 +102,7 @@ test('Accept a "parseOpts" and "writerOpts" objects as option', async t => {
       },
       writerOpts: (await promisify(require('conventional-changelog-eslint'))()).writerOpts,
     },
-    {options: {repositoryUrl}, lastRelease, nextRelease, commits}
+    {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
   );
 
   t.regex(changelog, new RegExp(escape('(https://github.com/owner/repo/compare/v1.0.0...v2.0.0)')));
@@ -136,7 +137,7 @@ test('Accept a partial "parseOpts" and "writerOpts" objects as option', async t 
       parserOpts: {headerPattern: /^(\w*)(?:\((.*)\)): (.*)$/},
       writerOpts: {commitsSort: ['subject', 'scope']},
     },
-    {options: {repositoryUrl}, lastRelease, nextRelease, commits}
+    {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
   );
 
   t.regex(changelog, new RegExp(escape('(https://github.com/owner/repo/compare/v1.0.0...v2.0.0)')));
@@ -151,7 +152,13 @@ test('Use "gitHead" from "lastRelease" and "nextRelease" if "gitTag" is not defi
   ];
   const changelog = await releaseNotesGenerator(
     {},
-    {options: {repositoryUrl}, lastRelease: {gitHead: 'abc'}, nextRelease: {gitHead: 'def', version: '2.0.0'}, commits}
+    {
+      cwd,
+      options: {repositoryUrl},
+      lastRelease: {gitHead: 'abc'},
+      nextRelease: {gitHead: 'def', version: '2.0.0'},
+      commits,
+    }
   );
 
   t.regex(changelog, new RegExp(escape('(https://github.com/owner/repo/compare/abc...def)')));
@@ -171,7 +178,7 @@ test('Accept a custom repository URL', async t => {
   ];
   const changelog = await releaseNotesGenerator(
     {},
-    {options: {repositoryUrl: 'http://domain.com:90/owner/repo'}, lastRelease, nextRelease, commits}
+    {cwd, options: {repositoryUrl: 'http://domain.com:90/owner/repo'}, lastRelease, nextRelease, commits}
   );
 
   t.regex(changelog, new RegExp(escape('(http://domain.com:90/owner/repo/compare/v1.0.0...v2.0.0)')));
@@ -191,7 +198,7 @@ test('Accept a custom repository URL with git format', async t => {
   ];
   const changelog = await releaseNotesGenerator(
     {},
-    {options: {repositoryUrl: 'git@domain.com:owner/repo.git'}, lastRelease, nextRelease, commits}
+    {cwd, options: {repositoryUrl: 'git@domain.com:owner/repo.git'}, lastRelease, nextRelease, commits}
   );
 
   t.regex(changelog, new RegExp(escape('(https://domain.com/owner/repo/compare/v1.0.0...v2.0.0)')));
@@ -211,7 +218,7 @@ test('Accept a custom repository URL with git+http format', async t => {
   ];
   const changelog = await releaseNotesGenerator(
     {},
-    {options: {repositoryUrl: 'git+http://domain.com:90/owner/repo'}, lastRelease, nextRelease, commits}
+    {cwd, options: {repositoryUrl: 'git+http://domain.com:90/owner/repo'}, lastRelease, nextRelease, commits}
   );
 
   t.regex(changelog, new RegExp(escape('(http://domain.com:90/owner/repo/compare/v1.0.0...v2.0.0)')));
@@ -231,7 +238,7 @@ test('Accept a custom repository URL with git+https format', async t => {
   ];
   const changelog = await releaseNotesGenerator(
     {},
-    {options: {repositoryUrl: 'git+https://domain.com:90/owner/repo'}, lastRelease, nextRelease, commits}
+    {cwd, options: {repositoryUrl: 'git+https://domain.com:90/owner/repo'}, lastRelease, nextRelease, commits}
   );
 
   t.regex(changelog, new RegExp(escape('(https://domain.com:90/owner/repo/compare/v1.0.0...v2.0.0)')));
@@ -258,7 +265,7 @@ test('Accept a Bitbucket repository URL', async t => {
   ];
   const changelog = await releaseNotesGenerator(
     {},
-    {options: {repositoryUrl: 'git+https://bitbucket.org/owner/repo'}, lastRelease, nextRelease, commits}
+    {cwd, options: {repositoryUrl: 'git+https://bitbucket.org/owner/repo'}, lastRelease, nextRelease, commits}
   );
 
   t.regex(changelog, new RegExp(escape('(https://bitbucket.org/owner/repo/compare/v1.0.0...v2.0.0)')));
@@ -285,7 +292,7 @@ test('Accept a Gitlab repository URL', async t => {
   ];
   const changelog = await releaseNotesGenerator(
     {},
-    {options: {repositoryUrl: 'git+https://gitlab.com/owner/repo'}, lastRelease, nextRelease, commits}
+    {cwd, options: {repositoryUrl: 'git+https://gitlab.com/owner/repo'}, lastRelease, nextRelease, commits}
   );
 
   t.regex(changelog, new RegExp(escape('(https://gitlab.com/owner/repo/compare/v1.0.0...v2.0.0)')));
@@ -310,7 +317,7 @@ test('Ignore malformatted commits and include valid ones', async t => {
     {hash: '111', message: 'fix(scope1): First fix'},
     {hash: '222', message: 'Feature => Invalid message'},
   ];
-  const changelog = await releaseNotesGenerator({}, {options: {repositoryUrl}, lastRelease, nextRelease, commits});
+  const changelog = await releaseNotesGenerator({}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
 
   t.regex(changelog, /### Bug Fixes/);
   t.regex(changelog, /\* \*\*scope1:\*\* First fix/);
@@ -324,7 +331,7 @@ test('Exclude commits if they have a matching revert commits', async t => {
     {hash: '222', message: 'feat(scope2): First feature'},
     {hash: '333', message: 'revert: feat(scope2): First feature\n\nThis reverts commit 222.\n'},
   ];
-  const changelog = await releaseNotesGenerator({}, {options: {repositoryUrl}, lastRelease, nextRelease, commits});
+  const changelog = await releaseNotesGenerator({}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
 
   t.regex(changelog, new RegExp(escape('(https://github.com/owner/repo/compare/v1.0.0...v2.0.0)')));
   t.regex(changelog, /### Bug Fixes/);
@@ -339,7 +346,10 @@ test('Throw error if "preset" doesn`t exist', async t => {
     {hash: '222', message: 'Update: Second feature (fixes #456)'},
   ];
   const error = await t.throws(
-    releaseNotesGenerator({preset: 'unknown-preset'}, {options: {repositoryUrl}, lastRelease, nextRelease, commits})
+    releaseNotesGenerator(
+      {preset: 'unknown-preset'},
+      {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
+    )
   );
 
   t.is(error.code, 'MODULE_NOT_FOUND');
@@ -351,7 +361,10 @@ test('Throw error if "config" doesn`t exist', async t => {
     {hash: '222', message: 'Update: Second feature (fixes #456)'},
   ];
   const error = await t.throws(
-    releaseNotesGenerator({config: 'unknown-config'}, {options: {repositoryUrl}, lastRelease, nextRelease, commits})
+    releaseNotesGenerator(
+      {config: 'unknown-config'},
+      {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
+    )
   );
 
   t.is(error.code, 'MODULE_NOT_FOUND');
@@ -371,7 +384,7 @@ test('ReThrow error from "conventional-changelog"', async t => {
           },
         },
       },
-      {options: {repositoryUrl}, lastRelease, nextRelease, commits}
+      {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
     )
   );
 

--- a/test/load-changelog-config.test.js
+++ b/test/load-changelog-config.test.js
@@ -1,6 +1,8 @@
 import test from 'ava';
 import loadChangelogConfig from '../lib/load-changelog-config';
 
+const cwd = process.cwd();
+
 /**
  * AVA macro to verify that `loadChangelogConfig` return a config object with parserOpts and writerOpts.
  *
@@ -9,7 +11,7 @@ import loadChangelogConfig from '../lib/load-changelog-config';
  * @param {[type]} preset the `conventional-changelog` preset to test.
  */
 async function loadPreset(t, preset) {
-  const changelogConfig = await loadChangelogConfig({preset});
+  const changelogConfig = await loadChangelogConfig({preset}, {cwd});
 
   t.truthy(changelogConfig.parserOpts.headerPattern);
   t.truthy(changelogConfig.writerOpts.groupBy);
@@ -24,7 +26,7 @@ loadPreset.title = (providedTitle, preset) => `${providedTitle} Load "${preset}"
  * @param {[type]} config the `conventional-changelog` config to test.
  */
 async function loadConfig(t, config) {
-  const changelogConfig = await loadChangelogConfig({config: `conventional-changelog-${config}`});
+  const changelogConfig = await loadChangelogConfig({config: `conventional-changelog-${config}`}, {cwd});
 
   t.truthy(changelogConfig.parserOpts.headerPattern);
   t.truthy(changelogConfig.writerOpts.groupBy);
@@ -32,7 +34,7 @@ async function loadConfig(t, config) {
 loadConfig.title = (providedTitle, config) => `${providedTitle} Load "${config}" config`.trim();
 
 test('Load "conventional-changelog-angular" by default', async t => {
-  const changelogConfig = await loadChangelogConfig({});
+  const changelogConfig = await loadChangelogConfig({}, {cwd});
   const angularChangelogConfig = await require('conventional-changelog-angular');
 
   t.deepEqual(changelogConfig.parserOpts, angularChangelogConfig.parserOpts);
@@ -41,7 +43,7 @@ test('Load "conventional-changelog-angular" by default', async t => {
 
 test('Accept a "parserOpts" object as option', async t => {
   const customParserOpts = {headerPattern: /^##(.*?)## (.*)$/, headerCorrespondence: ['tag', 'shortDesc']};
-  const changelogConfig = await loadChangelogConfig({parserOpts: customParserOpts});
+  const changelogConfig = await loadChangelogConfig({parserOpts: customParserOpts}, {cwd});
   const angularChangelogConfig = await require('conventional-changelog-angular');
 
   t.is(customParserOpts.headerPattern, changelogConfig.parserOpts.headerPattern);
@@ -52,7 +54,7 @@ test('Accept a "parserOpts" object as option', async t => {
 
 test('Accept a "writerOpts" object as option', async t => {
   const customWriterOpts = {commitGroupsSort: 'title', commitsSort: ['scope', 'subject']};
-  const changelogConfig = await loadChangelogConfig({writerOpts: customWriterOpts});
+  const changelogConfig = await loadChangelogConfig({writerOpts: customWriterOpts}, {cwd});
   const angularChangelogConfig = await require('conventional-changelog-angular');
 
   t.is(customWriterOpts.commitGroupsSort, changelogConfig.writerOpts.commitGroupsSort);
@@ -63,7 +65,7 @@ test('Accept a "writerOpts" object as option', async t => {
 
 test('Accept a partial "parserOpts" object as option that overwrite a preset', async t => {
   const customParserOpts = {headerPattern: /^##(.*?)## (.*)$/, headerCorrespondence: ['tag', 'shortDesc']};
-  const changelogConfig = await loadChangelogConfig({parserOpts: customParserOpts, preset: 'angular'});
+  const changelogConfig = await loadChangelogConfig({parserOpts: customParserOpts, preset: 'angular'}, {cwd});
   const angularChangelogConfig = await require('conventional-changelog-angular');
 
   t.is(customParserOpts.headerPattern, changelogConfig.parserOpts.headerPattern);
@@ -74,7 +76,7 @@ test('Accept a partial "parserOpts" object as option that overwrite a preset', a
 
 test('Accept a "writerOpts" object as option that overwrite a preset', async t => {
   const customWriterOpts = {commitGroupsSort: 'title', commitsSort: ['scope', 'subject']};
-  const changelogConfig = await loadChangelogConfig({writerOpts: customWriterOpts, preset: 'angular'});
+  const changelogConfig = await loadChangelogConfig({writerOpts: customWriterOpts, preset: 'angular'}, {cwd});
   const angularChangelogConfig = await require('conventional-changelog-angular');
 
   t.is(customWriterOpts.commitGroupsSort, changelogConfig.writerOpts.commitGroupsSort);
@@ -85,10 +87,13 @@ test('Accept a "writerOpts" object as option that overwrite a preset', async t =
 
 test('Accept a partial "parserOpts" object as option that overwrite a config', async t => {
   const customParserOpts = {headerPattern: /^##(.*?)## (.*)$/, headerCorrespondence: ['tag', 'shortDesc']};
-  const changelogConfig = await loadChangelogConfig({
-    parserOpts: customParserOpts,
-    config: 'conventional-changelog-angular',
-  });
+  const changelogConfig = await loadChangelogConfig(
+    {
+      parserOpts: customParserOpts,
+      config: 'conventional-changelog-angular',
+    },
+    {cwd}
+  );
   const angularChangelogConfig = await require('conventional-changelog-angular');
 
   t.is(customParserOpts.headerPattern, changelogConfig.parserOpts.headerPattern);
@@ -99,10 +104,13 @@ test('Accept a partial "parserOpts" object as option that overwrite a config', a
 
 test('Accept a "writerOpts" object as option that overwrite a config', async t => {
   const customWriterOpts = {commitGroupsSort: 'title', commitsSort: ['scope', 'subject']};
-  const changelogConfig = await loadChangelogConfig({
-    writerOpts: customWriterOpts,
-    config: 'conventional-changelog-angular',
-  });
+  const changelogConfig = await loadChangelogConfig(
+    {
+      writerOpts: customWriterOpts,
+      config: 'conventional-changelog-angular',
+    },
+    {cwd}
+  );
   const angularChangelogConfig = await require('conventional-changelog-angular');
 
   t.is(customWriterOpts.commitGroupsSort, changelogConfig.writerOpts.commitGroupsSort);
@@ -125,13 +133,13 @@ test(loadPreset, 'jshint');
 test(loadConfig, 'jshint');
 
 test('Throw error if "config" doesn`t exist', async t => {
-  const error = await t.throws(loadChangelogConfig({config: 'unknown-config'}));
+  const error = await t.throws(loadChangelogConfig({config: 'unknown-config'}, {cwd}));
 
   t.is(error.code, 'MODULE_NOT_FOUND');
 });
 
 test('Throw error if "preset" doesn`t exist', async t => {
-  const error = await t.throws(loadChangelogConfig({preset: 'unknown-preset'}));
+  const error = await t.throws(loadChangelogConfig({preset: 'unknown-preset'}, {cwd}));
 
   t.is(error.code, 'MODULE_NOT_FOUND');
 });


### PR DESCRIPTION
BREAKING CHANGE: require `semantic-release` >= `15.8.0`