### PR TITLE
fix: export as an object with `generateNotes` step

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # **release-notes-generator**
 
-Customizable release-notes-generator plugin for [semantic-release](https://github.com/semantic-release/semantic-release) based on [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)
+[**semantic-release**](https://github.com/semantic-release/semantic-release) plugin to generate changelog content with [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)
 
 [![Travis](https://img.shields.io/travis/semantic-release/release-notes-generator.svg)](https://travis-ci.org/semantic-release/release-notes-generator)
 [![Codecov](https://img.shields.io/codecov/c/github/semantic-release/release-notes-generator.svg)](https://codecov.io/gh/semantic-release/release-notes-generator)
@@ -9,16 +9,30 @@ Customizable release-notes-generator plugin for [semantic-release](https://githu
 [![npm latest version](https://img.shields.io/npm/v/@semantic-release/release-notes-generator/latest.svg)](https://www.npmjs.com/package/@semantic-release/release-notes-generator)
 [![npm next version](https://img.shields.io/npm/v/@semantic-release/release-notes-generator/next.svg)](https://www.npmjs.com/package/@semantic-release/release-notes-generator)
 
-## Options
+| Step            | Description                                                                                                                                                          |
+|-----------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `generateNotes` | Generate release notes for the commits added since the last release with [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog). |
 
-By default `release-notes-generator` uses the `angular` format described in [Angular convention](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular).
+## Install
 
-Additional options can be set within the plugin definition in `package.json` to use a different commit format and to customize it:
+```bash
+$ npm install @semantic-release/commit-analyzer -D
+```
+
+## Usage
+
+The plugin can be configured in the [**semantic-release** configuration file](https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/configuration.md#configuration):
 
 ```json
 {
-  "release": {
-    "generateNotes": {
+  "plugins": [
+    ["semantic-release/commit-analyzer", {
+      "preset": "angular",
+      "parserOpts": {
+        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+      },
+    }],
+    ["semantic-release/release-notes-generator", {
       "preset": "angular",
       "parserOpts": {
         "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
@@ -26,60 +40,28 @@ Additional options can be set within the plugin definition in `package.json` to 
       "writerOpts": {
         "commitsSort": ["subject", "scope"],
       }
-    }
-  }
+    }]
+  ]
 }
 ```
 
-| Option       | Description                                                                                                                                                                                                                                                                                        | Default   |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------- |
-| `preset`     | [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset (Possible values: `angular`, `atom`, `codemirror`, `ember`, `eslint`, `express`, `jquery`, `jscs`, `jshint`).                                                                                    | `angular` |
-| `config`     | NPM package name of a custom [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset.                                                                                                                                                                    | -         |
-| `parserOpts` | Additional [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#conventionalcommitsparseroptions) options that will extends ones loaded by `preset` or `config`. See [Parser options](#parser-options). | -         |
-| `writerOpts` | Additional [conventional-commits-writer](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-writer#options) options that will extends ones loaded by `preset` or `config`. See [Writer options](#writer-options).                        | -         |
+With this example:
+- the commits that contains `BREAKING CHANGE`, `BREAKING CHANGES` or `BREAKING` in their body will be considered breaking changes (by default the [angular preset](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/index.js#L14) checks only for `BREAKING CHANGE` and `BREAKING CHANGES`)
+- the commits will be sorted in the changelog by `subject` then `scope` (by default the [angular preset](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/index.js#L90) sort the commits in the changelog by `scope` then `subject`)
+
+## Configuration
+
+### Options
+
+| Option       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default                                                                                                                           |
+|--------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------|
+| `preset`     | [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset (possible values: [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular), [`atom`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-atom), [`codemirror`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-codemirror), [`ember`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-ember), [`eslint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint), [`express`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-express), [`jquery`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jquery), [`jshint`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-jshint)). | [`angular`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular) |
+| `config`     | NPM package name of a custom [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    | -                                                                                                                                 |
+| `parserOpts` | Additional [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#conventionalcommitsparseroptions) options that will extends the ones loaded by `preset` or `config`. This is convenient to use a [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset with some customizations without having to create a new module.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      | -                                                                                                                                 |
+| `writerOpts` | Additional [conventional-commits-writer](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-writer#options) options that will extends the ones loaded by `preset` or `config`. This is convenient to use a [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset with some customizations without having to create a new module.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             | -                                                                                                                                 |
+
+**Notes**: in order to use a `preset` it must be installed (for example to use the [eslint preset](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-eslint) you must install it with `npm install conventional-changelog-eslint -D`)
 
 **Note**: `config` will be overwritten by the values of `preset`. You should use either `preset` or `config`, but not both.
 
 **Note**: Individual properties of `parserOpts` and `writerOpts` will override ones loaded with an explicitly set `preset` or `config`. If `preset` or `config` are not set, only the properties set in `parserOpts` and `writerOpts` will be used.
-
-### Parser Options
-
-Allow to overwrite specific [conventional-commits-parser](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-commits-parser#conventionalcommitsparseroptions) options. This is convenient to use a [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset with some customizations without having to create a new module.
-
-The following example uses [Angular convention](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/convention.md) but will consider a commit to be a breaking change if it's body contains `BREAKING CHANGE`, `BREAKING CHANGES` or `BREAKING`. By default the [preset](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/index.js#L14) checks only for `BREAKING CHANGE` and `BREAKING CHANGES`.
-
-```json
-{
-  "release": {
-    "generateNotes": {
-      "preset": "angular",
-      "parserOpts": {
-        "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"],
-      }
-    }
-  }
-}
-```
-
-### Writer Options
-
-Allow to overwrite specific [conventional-commits-writer](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-writer#options) options. This is convenient to use a [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog) preset with some customizations without having to create a new module.
-
-The following example uses [Angular convention](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/convention.md) but will sort the commits in the changelog by `subject` then `scope`. By default the [preset](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-angular/index.js#L90) sort the commits in the changelog by `scope` then `subject`.
-
-```json
-{
-  "release": {
-    "generateNotes": {
-      "preset": "angular",
-      "writerOpts": {
-        "commitsSort": ["subject", "scope"],
-      }
-    }
-  }
-}
-```
-
-## Usage
-
-The plugin is used by default by [semantic-release](https://github.com/semantic-release/semantic-release) so installing it is not necessary and all configuration are optionals.

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const HOSTS_CONFIG = require('./lib/hosts-config');
  *
  * @returns {String} The changelog for all the commits in `context.commits`.
  */
-async function releaseNotesGenerator(pluginConfig, context) {
+async function generateNotes(pluginConfig, context) {
   const {
     commits,
     lastRelease,
@@ -70,4 +70,4 @@ async function releaseNotesGenerator(pluginConfig, context) {
   return getStream(intoStream.obj(parsedCommits).pipe(writer(changelogContext, writerOpts)));
 }
 
-module.exports = releaseNotesGenerator;
+module.exports = {generateNotes};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-release/release-notes-generator",
-  "description": "Customizable release-notes-generator plugin for semantic-release",
+  "description": "semantic-release plugin to generate changelog content with conventional-changelog",
   "version": "0.0.0-development",
   "author": "Pierre Vanduynslager (https://twitter.com/@pvdlg_)",
   "bugs": {

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,7 +1,7 @@
 import {promisify} from 'util';
 import test from 'ava';
 import escape from 'escape-string-regexp';
-import releaseNotesGenerator from '..';
+import {generateNotes} from '..';
 
 const cwd = process.cwd();
 const repositoryUrl = 'https://github.com/owner/repo';
@@ -13,7 +13,7 @@ test('Use "conventional-changelog-angular" by default', async t => {
     {hash: '111', message: 'fix(scope1): First fix'},
     {hash: '222', message: 'feat(scope2): Second feature'},
   ];
-  const changelog = await releaseNotesGenerator({}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
+  const changelog = await generateNotes({}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
 
   t.regex(changelog, new RegExp(escape('(https://github.com/owner/repo/compare/v1.0.0...v2.0.0)')));
   t.regex(changelog, /### Bug Fixes/);
@@ -30,7 +30,7 @@ test('Accept a "preset" option', async t => {
     {hash: '111', message: 'Fix: First fix (fixes #123)'},
     {hash: '222', message: 'Update: Second feature (fixes #456)'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {preset: 'eslint'},
     {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
   );
@@ -61,7 +61,7 @@ test('Accept a "config" option', async t => {
     {hash: '111', message: 'Fix: First fix (fixes #123)'},
     {hash: '222', message: 'Update: Second feature (fixes #456)'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {config: 'conventional-changelog-eslint'},
     {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
   );
@@ -92,7 +92,7 @@ test('Accept a "parseOpts" and "writerOpts" objects as option', async t => {
     {hash: '111', message: '%%Fix%% First fix (keyword #123)'},
     {hash: '222', message: '%%Update%% Second feature (keyword JIRA-456)'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {
       parserOpts: {
         headerPattern: /^%%(.*?)%% (.*)$/,
@@ -131,7 +131,7 @@ test('Accept a partial "parseOpts" and "writerOpts" objects as option', async t 
     {hash: '111', message: 'fix(scope1): 2 First fix (fixes #123)'},
     {hash: '222', message: 'fix(scope2): 1 Second fix (fixes #456)'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {
       preset: 'angular',
       parserOpts: {headerPattern: /^(\w*)(?:\((.*)\)): (.*)$/},
@@ -150,7 +150,7 @@ test('Use "gitHead" from "lastRelease" and "nextRelease" if "gitTag" is not defi
     {hash: '111', message: 'fix(scope1): First fix'},
     {hash: '222', message: 'feat(scope2): Second feature'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {},
     {
       cwd,
@@ -176,7 +176,7 @@ test('Accept a custom repository URL', async t => {
     {hash: '111', message: 'fix(scope1): First fix'},
     {hash: '222', message: 'feat(scope2): Second feature'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {},
     {cwd, options: {repositoryUrl: 'http://domain.com:90/owner/repo'}, lastRelease, nextRelease, commits}
   );
@@ -196,7 +196,7 @@ test('Accept a custom repository URL with git format', async t => {
     {hash: '111', message: 'fix(scope1): First fix'},
     {hash: '222', message: 'feat(scope2): Second feature'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {},
     {cwd, options: {repositoryUrl: 'git@domain.com:owner/repo.git'}, lastRelease, nextRelease, commits}
   );
@@ -216,7 +216,7 @@ test('Accept a custom repository URL with git+http format', async t => {
     {hash: '111', message: 'fix(scope1): First fix'},
     {hash: '222', message: 'feat(scope2): Second feature'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {},
     {cwd, options: {repositoryUrl: 'git+http://domain.com:90/owner/repo'}, lastRelease, nextRelease, commits}
   );
@@ -236,7 +236,7 @@ test('Accept a custom repository URL with git+https format', async t => {
     {hash: '111', message: 'fix(scope1): First fix\n\nresolve #10'},
     {hash: '222', message: 'feat(scope2): Second feature'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {},
     {cwd, options: {repositoryUrl: 'git+https://domain.com:90/owner/repo'}, lastRelease, nextRelease, commits}
   );
@@ -263,7 +263,7 @@ test('Accept a Bitbucket repository URL', async t => {
     {hash: '111', message: 'fix(scope1): First fix\n\nResolves #10'},
     {hash: '222', message: 'feat(scope2): Second feature'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {},
     {cwd, options: {repositoryUrl: 'git+https://bitbucket.org/owner/repo'}, lastRelease, nextRelease, commits}
   );
@@ -290,7 +290,7 @@ test('Accept a Gitlab repository URL', async t => {
     {hash: '111', message: 'fix(scope1): First fix\n\nclosed #10'},
     {hash: '222', message: 'feat(scope2): Second feature'},
   ];
-  const changelog = await releaseNotesGenerator(
+  const changelog = await generateNotes(
     {},
     {cwd, options: {repositoryUrl: 'git+https://gitlab.com/owner/repo'}, lastRelease, nextRelease, commits}
   );
@@ -317,7 +317,7 @@ test('Ignore malformatted commits and include valid ones', async t => {
     {hash: '111', message: 'fix(scope1): First fix'},
     {hash: '222', message: 'Feature => Invalid message'},
   ];
-  const changelog = await releaseNotesGenerator({}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
+  const changelog = await generateNotes({}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
 
   t.regex(changelog, /### Bug Fixes/);
   t.regex(changelog, /\* \*\*scope1:\*\* First fix/);
@@ -331,7 +331,7 @@ test('Exclude commits if they have a matching revert commits', async t => {
     {hash: '222', message: 'feat(scope2): First feature'},
     {hash: '333', message: 'revert: feat(scope2): First feature\n\nThis reverts commit 222.\n'},
   ];
-  const changelog = await releaseNotesGenerator({}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
+  const changelog = await generateNotes({}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
 
   t.regex(changelog, new RegExp(escape('(https://github.com/owner/repo/compare/v1.0.0...v2.0.0)')));
   t.regex(changelog, /### Bug Fixes/);
@@ -346,10 +346,7 @@ test('Throw error if "preset" doesn`t exist', async t => {
     {hash: '222', message: 'Update: Second feature (fixes #456)'},
   ];
   const error = await t.throws(
-    releaseNotesGenerator(
-      {preset: 'unknown-preset'},
-      {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
-    )
+    generateNotes({preset: 'unknown-preset'}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits})
   );
 
   t.is(error.code, 'MODULE_NOT_FOUND');
@@ -361,10 +358,7 @@ test('Throw error if "config" doesn`t exist', async t => {
     {hash: '222', message: 'Update: Second feature (fixes #456)'},
   ];
   const error = await t.throws(
-    releaseNotesGenerator(
-      {config: 'unknown-config'},
-      {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits}
-    )
+    generateNotes({config: 'unknown-config'}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits})
   );
 
   t.is(error.code, 'MODULE_NOT_FOUND');
@@ -376,7 +370,7 @@ test('ReThrow error from "conventional-changelog"', async t => {
     {hash: '222', message: 'Update: Second feature (fixes #456)'},
   ];
   const error = await t.throws(
-    releaseNotesGenerator(
+    generateNotes(
       {
         writerOpts: {
           transform() {


### PR DESCRIPTION
child of semantic-release/semantic-release#936