### PR TITLE
fix: add `packageData` to `conventional-changelog-writer` context

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const intoStream = require('into-stream');
 const parser = require('conventional-commits-parser').sync;
 const writer = require('conventional-changelog-writer');
 const filter = require('conventional-commits-filter');
+const readPkgUp = require('read-pkg-up');
 const debug = require('debug')('semantic-release:release-notes-generator');
 const loadChangelogConfig = require('./lib/load-changelog-config');
 const HOSTS_CONFIG = require('./lib/hosts-config');
@@ -26,7 +27,7 @@ const HOSTS_CONFIG = require('./lib/hosts-config');
  * @returns {String} The changelog for all the commits in `context.commits`.
  */
 async function generateNotes(pluginConfig, context) {
-  const {commits, lastRelease, nextRelease, options} = context;
+  const {commits, lastRelease, nextRelease, options, cwd} = context;
   const repositoryUrl = options.repositoryUrl.replace(/\.git$/i, '');
   const {parserOpts, writerOpts} = await loadChangelogConfig(pluginConfig, context);
 
@@ -59,6 +60,7 @@ async function generateNotes(pluginConfig, context) {
       linkCompare: currentTag && previousTag,
       issue,
       commit,
+      packageData: ((await readPkgUp({normalize: false, cwd})) || {}).package,
     },
     {host: hostConfig, linkCompare, linkReferences, commit: commitConfig, issue: issueConfig}
   );

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "get-stream": "^5.0.0",
     "import-from": "^3.0.0",
     "into-stream": "^5.0.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "read-pkg-up": "^6.0.0"
   },
   "devDependencies": {
     "ava": "^2.0.0",
@@ -37,8 +38,12 @@
     "conventional-changelog-jshint": "^2.0.0",
     "cz-conventional-changelog": "^2.0.0",
     "escape-string-regexp": "^2.0.0",
+    "fs-extra": "^8.0.1",
     "nyc": "^14.0.0",
+    "proxyquire": "^2.1.0",
     "semantic-release": "^15.0.0",
+    "sinon": "^7.3.2",
+    "tempy": "^0.3.0",
     "xo": "^0.24.0"
   },
   "engines": {


### PR DESCRIPTION
Fix semantic-release/semantic-release#1219