### PR TITLE
docs(readme): fix typos in usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ The plugin can be configured in the [**semantic-release** configuration file](ht
 ```json
 {
   "plugins": [
-    ["semantic-release/commit-analyzer", {
+    ["@semantic-release/commit-analyzer", {
       "preset": "angular",
       "parserOpts": {
         "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
       }
     }],
-    ["semantic-release/release-notes-generator", {
+    ["@semantic-release/release-notes-generator", {
       "preset": "angular",
       "parserOpts": {
         "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]


### PR DESCRIPTION
The plugins in the usage section were missing the "@" symbol. I caught this because I copied this and using it in my `package.json` and kept getting errors 😂