### PR TITLE
chore: remove duplicate "host" debug statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -76,7 +76,6 @@ async function generateNotes(pluginConfig, context) {
   );
 
   debug('version: %o', changelogContext.version);
-  debug('host: %o', changelogContext.hostname);
   debug('owner: %o', changelogContext.owner);
   debug('repository: %o', changelogContext.repository);
   debug('previousTag: %o', changelogContext.previousTag);


### PR DESCRIPTION
A value for "host" was being printed twice, the first of which was always `undefined` because the property `changelogContext.hostname` is never set (and is not part of conventional-changelog's API).