### PR TITLE
Fix parsing of non-standard repository URLs.

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ async function generateNotes(pluginConfig, context) {
   );
   port = protocol.includes('ssh') ? '' : port;
   protocol = protocol && /http[^s]/.test(protocol) ? 'http' : 'https';
-  const [, owner, repository] = /^\/(?<owner>[^/]+)?\/?(?<repository>.+)?$/.exec(pathname);
+  const [, owner, repository] = /^\/(?<owner>[^/]+)?\/?(?<repository>.+)?$/.exec(pathname) || [];
 
   const {issue, commit, referenceActions, issuePrefixes} =
     find(HOSTS_CONFIG, conf => conf.hostname === hostname) || HOSTS_CONFIG.default;

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -462,6 +462,30 @@ test('Accept a Gitlab repository URL', async t => {
   );
 });
 
+test('Accept a custom AWS CodeCommit repository URL', async t => {
+  const commits = [
+    {hash: '111', message: 'fix(scope1): First fix'},
+    {hash: '222', message: 'feat(scope2): Second feature'},
+  ];
+  const changelog = await generateNotes(
+    {},
+    {
+      cwd,
+      options: {
+        repositoryUrl: 'codecommit::eu-central-1://profile@repository-name',
+      },
+      lastRelease,
+      nextRelease,
+      commits,
+    }
+  );
+
+  t.regex(changelog, /### Bug Fixes/);
+  t.regex(changelog, new RegExp(escape('* **scope1:** First fix 111')));
+  t.regex(changelog, /### Features/);
+  t.regex(changelog, new RegExp(escape('* **scope2:** Second feature 222')));
+});
+
 test('Accept a "linkCompare" option', async t => {
   const commits = [
     {hash: '111', message: 'fix(scope1): First fix\n\nResolves #10'},


### PR DESCRIPTION
This should fix #182.

AWS CodeCommit uses non-standard Git Repositoy URLs, which currently fail execution of the plugin. This fix prevents the exception.