### PR TITLE
feat: add option for custom release note header

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,8 +97,10 @@ async function generateNotes(pluginConfig, context) {
     if(headerOpt === fspath.basename(headerOpt)) {
       res =  headerOpt + '\n' + res;
     } else {
-      const header = fs.readFileSync(headerOpt, { encoding: 'utf8' });
-      res = header + '\n' + res;
+      if(fs.existsSync(pluginConfig['header'])) {
+        const header = fs.readFileSync(headerOpt, { encoding: 'utf8' });
+        res = header + '\n' + res;
+      }
     }
   }
 
@@ -108,8 +110,10 @@ async function generateNotes(pluginConfig, context) {
     if(footerOpt === fspath.basename(footerOpt)) {
       res = res + '\n' + footerOpt
     } else {
-      const footer = fs.readFileSync(footerOpt, { encoding: 'utf8' });
-      res = res + '\n' + footer
+      if(fs.existsSync(pluginConfig['footer'])) {
+        const footer = fs.readFileSync(footerOpt, { encoding: 'utf8' });
+        res = res + '\n' + footer
+      }
     }
   }
   

--- a/index.js
+++ b/index.js
@@ -95,10 +95,21 @@ async function generateNotes(pluginConfig, context) {
     var headerOpt = pluginConfig['header'];
 
     if(headerOpt === fspath.basename(headerOpt)) {
-      res =  headerOpt + "\n" + res;
+      res =  headerOpt + '\n' + res;
     } else {
       const header = fs.readFileSync(headerOpt, { encoding: 'utf8' });
-      res = header + "\n" + res;
+      res = header + '\n' + res;
+    }
+  }
+
+  if('footer' in pluginConfig) {
+    var footerOpt = pluginConfig['footer'];
+
+    if(footerOpt === fspath.basename(footerOpt)) {
+      res = res + '\n' + footerOpt
+    } else {
+      const footer = fs.readFileSync(footerOpt, { encoding: 'utf8' });
+      res = res + '\n' + footer
     }
   }
   

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -648,7 +648,7 @@ test('Accept "header" file path option', async(t) => {
 
   const releaseNotes = await generateNotes({header: './test/testHeader.md'}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
   t.regex(releaseNotes, /### Test Header/);
-})
+});
 
 test('Accept "header" string option', async(t) => {
   const commits = [
@@ -658,4 +658,24 @@ test('Accept "header" string option', async(t) => {
 
   const releaseNotes = await generateNotes({header: "### Test Header"}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
   t.regex(releaseNotes, /### Test Header/);
-})
+});
+
+test('Accept "footer" file path option', async(t) => {
+  const commits = [
+    {hash: '111', message: 'fix(scope1): First fix'},
+    {hash: '222', message: 'feat(scope2): First feature'},
+  ];
+
+  const releaseNotes = await generateNotes({footer: './test/testHeader.md'}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits})
+  t.regex(releaseNotes, /### Test Header/);
+});
+
+test('Accept "footer" string option', async(t) => {
+  const commits = [
+    {hash: '111', message: 'fix(scope1): First fix'},
+    {hash: '222', message: 'feat(scope2): First feature'},
+  ];
+
+  const releaseNotes = await generateNotes({footer: "### Test Footer"}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
+  t.regex(releaseNotes, /### Test Footer/);
+});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -639,3 +639,23 @@ test('ReThrow error from "conventional-changelog"', async (t) => {
     {message: 'Test error'}
   );
 });
+
+test('Accept "header" file path option', async(t) => {
+  const commits = [
+    {hash: '111', message: 'fix(scope1): First fix'},
+    {hash: '222', message: 'feat(scope2): First feature'},
+  ];
+
+  const releaseNotes = await generateNotes({header: './test/testHeader.md'}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
+  t.regex(releaseNotes, /### Test Header/);
+})
+
+test('Accept "header" string option', async(t) => {
+  const commits = [
+    {hash: '111', message: 'fix(scope1): First fix'},
+    {hash: '222', message: 'feat(scope2): First feature'},
+  ];
+
+  const releaseNotes = await generateNotes({header: "### Test Header"}, {cwd, options: {repositoryUrl}, lastRelease, nextRelease, commits});
+  t.regex(releaseNotes, /### Test Header/);
+})

--- a/test/testHeader.md
+++ b/test/testHeader.md
@@ -1,0 +1,1 @@
+### Test Header


### PR DESCRIPTION
## Description

Simple feature to allow adding a custom header for the release notes which is not related to the changelog itself. (As requested in #263).

## Usage

You can add a custom header by providing the `header` option to `pluginConfig`.
The `header` option should be either:
- a string (which is inserted at top of release notes)
- a relative file path to a text file (useful for auto-generating the header)

The string or contents of the file will be inserted at the top of the release notes itself.

### example config

*From string* 
```
{
  "plugins": [
    "@semantic-release/commit-analyzer",
    ["@semantic-release/release-notes-generator", {
      "header": "# My awesome custom header"
    }]
  ]
}
```

*From file*
```
  "plugins": [
    "@semantic-release/commit-analyzer",
    ["@semantic-release/release-notes-generator", {
      "header": "./my/custom/header.md"
    }]
  ]
}
```