### PR TITLE
fix: add support for repository suffix and add "/-" as GitLab repo suffix

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ export async function generateNotes(pluginConfig, context) {
   protocol = protocol && /http[^s]/.test(protocol) ? "http" : "https";
   const [, owner, repository] = /^\/(?<owner>[^/]+)?\/?(?<repository>.+)?$/.exec(pathname);
 
-  const { issue, commit, referenceActions, issuePrefixes } =
+  const { issue, commit, referenceActions, issuePrefixes, repositoryPathSuffix } =
     find(HOSTS_CONFIG, (conf) => conf.hostname === hostname) || HOSTS_CONFIG.default;
   const parsedCommits = filter(
     commits
@@ -66,7 +66,7 @@ export async function generateNotes(pluginConfig, context) {
       version: nextRelease.version,
       host: format({ protocol, hostname, port }),
       owner,
-      repository,
+      repository: repositoryPathSuffix ? `${repository}${repositoryPathSuffix}` : repository,
       previousTag,
       currentTag,
       linkCompare: currentTag && previousTag,

--- a/lib/hosts-config.js
+++ b/lib/hosts-config.js
@@ -32,6 +32,7 @@ export default {
     commit: "commit",
     referenceActions: ["close", "closes", "closed", "closing", "fix", "fixes", "fixed", "fixing"],
     issuePrefixes: ["#"],
+    repositoryPathSuffix: "/-",
   },
   default: {
     issue: "issues",

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -478,20 +478,20 @@ test.serial("Accept a Gitlab repository URL", async (t) => {
     { cwd, options: { repositoryUrl: "git+https://gitlab.com/owner/repo" }, lastRelease, nextRelease, commits }
   );
 
-  t.regex(changelog, new RegExp(escape("(https://gitlab.com/owner/repo/compare/v1.0.0...v2.0.0)")));
+  t.regex(changelog, new RegExp(escape("(https://gitlab.com/owner/repo/-/compare/v1.0.0...v2.0.0)")));
   t.regex(changelog, /### Bug Fixes/);
   t.regex(
     changelog,
     new RegExp(
       escape(
-        "* **scope1:** First fix ([111](https://gitlab.com/owner/repo/commit/111)), closes [#10](https://gitlab.com/owner/repo/issues/10)"
+        "* **scope1:** First fix ([111](https://gitlab.com/owner/repo/-/commit/111)), closes [#10](https://gitlab.com/owner/repo/-/issues/10)"
       )
     )
   );
   t.regex(changelog, /### Features/);
   t.regex(
     changelog,
-    new RegExp(escape("* **scope2:** Second feature ([222](https://gitlab.com/owner/repo/commit/222))"))
+    new RegExp(escape("* **scope2:** Second feature ([222](https://gitlab.com/owner/repo/-/commit/222))"))
   );
 });
 


### PR DESCRIPTION
Addresses the https://github.com/semantic-release/release-notes-generator/issues/449 issue.

@travi , please let me know is this an acceptable way to handle this or you would prefer some other way. I found it not really  convenient for any other approach + TypeScript would help a lot in the future :grin:

Anything else would require work inside `conventional-changelog-writer` and also possibly in every changelog template. For example [conventional-changelog-eslint](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-eslint/templates/header.hbs) has `...{{@root.repository}}/compare/{{previousTag}}...{{currentTag}}...`