### PR TITLE
Change to use `stream.ToArray`

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,5 +88,13 @@ export async function generateNotes(pluginConfig, context) {
   debug("issue: %o", changelogContext.issue);
   debug("commit: %o", changelogContext.commit);
 
-  return getStream(intoStream.object(parsedCommits).pipe(writer(changelogContext, writerOpts)));
+  const stream = intoStream.object(parsedCommits).pipe(writer(changelogContext, writerOpts));
+
+  debug("stream: %o", stream);
+
+  const changeLogContent = await stream.toArray();
+
+  return changeLogContent.join('');
+
+  // return getStream(intoStream.object(parsedCommits).pipe(writer(changelogContext, writerOpts)));
 }

--- a/index.js
+++ b/index.js
@@ -88,9 +88,7 @@ export async function generateNotes(pluginConfig, context) {
   debug("issue: %o", changelogContext.issue);
   debug("commit: %o", changelogContext.commit);
 
-  const stream = intoStream.object(parsedCommits).pipe(writer(changelogContext, writerOpts));
-
-  debug("stream: %o", stream);
+  const stream = intoStream.object(parsedCommits).pipe(writer(changelogContext, writerOpts));  
 
   const changeLogContent = await stream.toArray();
 


### PR DESCRIPTION
According to issue sindresorhus/get-stream#50, there are issues with using get-stream when using node versions
>= 18.14.0 and >=19.5.0. The method now used is taken directly
from the `get-stream` readme, and makes sense in this relatively simple scenario.

Should close #459 