### PR TITLE
chore: remove lodash-es

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
         "get-stream": "^7.0.0",
         "import-from-esm": "^2.0.0",
         "into-stream": "^7.0.0",
-        "lodash-es": "^4.17.21",
         "read-package-up": "^11.0.0"
       },
       "devDependencies": {
@@ -5603,6 +5602,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.capitalize": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "get-stream": "^7.0.0",
     "import-from-esm": "^2.0.0",
     "into-stream": "^7.0.0",
-    "lodash-es": "^4.17.21",
     "read-package-up": "^11.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We can drop lodash-es for the following replacements:

- `find` - use `Object.values(obj).find`
- `merge` - all of our values other than the `packageJson` are
  primitive, so we can just use `??` to fall back to defaults inline
