### PR TITLE
feat(preset): support ignoreCommits option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,5 +80,3 @@ With this example:
 **Note**: Individual properties of `parserOpts` and `writerOpts` will override ones loaded with an explicitly set `preset` or `config`. If `preset` or `config` are not set, only the properties set in `parserOpts` and `writerOpts` will be used.
 
 **Note**: For presets that expects a configuration object, such as [`conventionalcommits`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits), the `presetConfig` option **must** be set.
-
-**Note**: `ignoreCommits` is a supported option within `presetConfig` option when [`conventionalcommits`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits#specific-options) preset is used.

--- a/README.md
+++ b/README.md
@@ -80,3 +80,5 @@ With this example:
 **Note**: Individual properties of `parserOpts` and `writerOpts` will override ones loaded with an explicitly set `preset` or `config`. If `preset` or `config` are not set, only the properties set in `parserOpts` and `writerOpts` will be used.
 
 **Note**: For presets that expects a configuration object, such as [`conventionalcommits`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits), the `presetConfig` option **must** be set.
+
+**Note**: `ignoreCommits` is a supported option within `presetConfig` option when [`conventionalcommits`](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits#specific-options) preset is used.

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ const debug = debugFactory("semantic-release:release-notes-generator");
 export async function generateNotes(pluginConfig, context) {
   const { commits, lastRelease, nextRelease, options, cwd } = context;
   const repositoryUrl = options.repositoryUrl.replace(/\.git$/i, "");
-  const { commitsOpts, parserOpts, writerOpts } = await loadChangelogConfig(pluginConfig, context);
+  const { commitOpts, parserOpts, writerOpts } = await loadChangelogConfig(pluginConfig, context);
 
   const [match, auth, host, path] = /^(?!.+:\/\/)(?:(?<auth>.*)@)?(?<host>.*?):(?<path>.*)$/.exec(repositoryUrl) || [];
   let { hostname, port, pathname, protocol } = new URL(
@@ -52,7 +52,7 @@ export async function generateNotes(pluginConfig, context) {
           return false;
         }
 
-        if(commitsOpts && commitsOpts.ignore && new RegExp(commitsOpts.ignore).test(message) && !commitsOpts.merges){
+        if(commitOpts && commitOpts.ignore && new RegExp(commitOpts.ignore).test(message) && !commitOpts.merges){
           debug("Skip commit %s by ignore option", hash);
           return false;
         }

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ export async function generateNotes(pluginConfig, context) {
 
   const { issue, commit, referenceActions, issuePrefixes } =
     find(HOSTS_CONFIG, (conf) => conf.hostname === hostname) || HOSTS_CONFIG.default;
-  const parser = new CommitParser({ referenceActions, issuePrefixes, ...parserOpts});
+  const parser = new CommitParser({ referenceActions, issuePrefixes, ...parserOpts });
   const parsedCommits = filterRevertedCommitsSync(
     commits
       .filter(({ message, hash }) => {
@@ -52,7 +52,7 @@ export async function generateNotes(pluginConfig, context) {
           return false;
         }
 
-        if(commitOpts && commitOpts.ignore && new RegExp(commitOpts.ignore).test(message) && !commitOpts.merges){
+        if (commitOpts && commitOpts.ignore && new RegExp(commitOpts.ignore).test(message) && !commitOpts.merges) {
           debug("Skip commit %s by ignore option", hash);
           return false;
         }

--- a/lib/load-changelog-config.js
+++ b/lib/load-changelog-config.js
@@ -33,6 +33,7 @@ export default async ({ preset, config, parserOpts, writerOpts, presetConfig }, 
   }
 
   return {
+    commitsOpts: loadedConfig.commits,
     parserOpts: { ...loadedConfig.parser, ...parserOpts },
     writerOpts: { ...loadedConfig.writer, ...writerOpts },
   };

--- a/lib/load-changelog-config.js
+++ b/lib/load-changelog-config.js
@@ -33,7 +33,7 @@ export default async ({ preset, config, parserOpts, writerOpts, presetConfig }, 
   }
 
   return {
-    commitsOpts: loadedConfig.commits,
+    commitOpts: loadedConfig.commits,
     parserOpts: { ...loadedConfig.parser, ...parserOpts },
     writerOpts: { ...loadedConfig.writer, ...writerOpts },
   };

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -249,6 +249,32 @@ test.serial('Accept a partial "presetConfig" object as option', async (t) => {
   t.regex(changelog, new RegExp(escape("* Change test ([222](https://github.com/owner/repo/commit/222))")));
 });
 
+test.serial('Accept ignoreCommits in "presetConfig" object as option', async (t) => {
+  const { generateNotes } = await import("../index.js");
+  const commits = [
+    { hash: "111", message: "fix: First fix" },
+    { hash: "222", message: "test: Change test [python]" },
+  ];
+  const changelog = await generateNotes(
+    {
+      preset: "conventionalcommits",
+      presetConfig: {
+        ignoreCommits: '\\[python\\]',
+        types: [
+          { type: "fix", section: "Bug Fixes", hidden: false },
+          { type: "test", section: "Test !!", hidden: false },
+        ],
+      },
+    },
+    { cwd, options: { repositoryUrl }, lastRelease, nextRelease, commits }
+  );
+
+  t.regex(changelog, /### Bug Fixes/);
+  t.regex(changelog, new RegExp(escape("First fix")));
+  t.notRegex(changelog, /### Test !!/);
+  t.notRegex(changelog, new RegExp(escape("* Change test ([222](https://github.com/owner/repo/commit/222))")));
+});
+
 test.serial('Use "gitHead" from "lastRelease" and "nextRelease" if "gitTag" is not defined', async (t) => {
   const { generateNotes } = await import("../index.js");
   const commits = [

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -259,7 +259,7 @@ test.serial('Accept ignoreCommits in "presetConfig" object as option', async (t)
     {
       preset: "conventionalcommits",
       presetConfig: {
-        ignoreCommits: '\\[python\\]',
+        ignoreCommits: "\\[python\\]",
         types: [
           { type: "fix", section: "Bug Fixes", hidden: false },
           { type: "test", section: "Test !!", hidden: false },


### PR DESCRIPTION
conventional commits preset support ignoreCommits options from https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/index.js#L11. This is an extension of release-notes-generator for supporting this option from this preset.
I've been trying to ignore few specific patterns from one of my repos like messages that contains [python] string. This is successfully working commit-analyzer level with this plugin config:
```
[
        "@semantic-release/commit-analyzer",
        {
          "releaseRules": [
            {
              "message": "*\\[python\\]*",
              "release": false
            }
          ]
        }
      ],
```
but when generating release notes with the following config:
```
[
        "@semantic-release/release-notes-generator",
        {
          "preset": "conventionalcommits",
          "presetConfig": {
            "ignoreCommits": "\\[python\\]"
          }
]
```
that conventional commits seems to receive, it's not working. This pr is trying to support this existing presetConfig https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits#specific-options, this option is being passed [here](https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-changelog-conventionalcommits/src/index.js#L11)