### PR TITLE
chore: update README to replace 'next' badge with 'beta'

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [**semantic-release**](https://github.com/semantic-release/semantic-release) plugin to generate changelog content with [conventional-changelog](https://github.com/conventional-changelog/conventional-changelog)
 
 [![Build Status](https://github.com/semantic-release/release-notes-generator/workflows/Test/badge.svg)](https://github.com/semantic-release/release-notes-generator/actions?query=workflow%3ATest+branch%3Amaster) [![npm latest version](https://img.shields.io/npm/v/@semantic-release/release-notes-generator/latest.svg)](https://www.npmjs.com/package/@semantic-release/release-notes-generator)
-[![npm next version](https://img.shields.io/npm/v/@semantic-release/release-notes-generator/next.svg)](https://www.npmjs.com/package/@semantic-release/release-notes-generator)
+[![npm beta version](https://img.shields.io/npm/v/@semantic-release/release-notes-generator/beta.svg)](https://www.npmjs.com/package/@semantic-release/release-notes-generator)
 
 | Step            | Description                                                                                                                                                          |
 | --------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
This pull request makes a small update to the `README.md` file, changing the npm badge from "next" to "beta" to reflect the current release channel.